### PR TITLE
Use add_provider(), and include directly on Injector

### DIFF
--- a/dependency/__init__.py
+++ b/dependency/__init__.py
@@ -1,9 +1,9 @@
 from dependency.core import Injector, InjectedFunction, ParamName
-from dependency.wrappers import provider, inject, set_required_state
+from dependency.wrappers import add_provider, inject, set_required_state
 
 
 __version__ = '0.0.2'
 __all__ = [
     'Injector', 'InjectedFunction', 'ParamName',
-    'provider', 'inject', 'set_required_state'
+    'add_provider', 'inject', 'set_required_state'
 ]

--- a/dependency/core.py
+++ b/dependency/core.py
@@ -99,6 +99,12 @@ class Injector():
         self.providers = providers
         self.required_state = required_state
 
+    def add_provider(self, func: typing.Callable) -> None:
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty
+        assert not isinstance(sig.return_annotation, str)
+        self.providers[sig.return_annotation] = func
+
     def inject(self, func: typing.Callable) -> InjectedFunction:
         parameterized_types = set([
             provided_type for provided_type, provider_func

--- a/dependency/wrappers.py
+++ b/dependency/wrappers.py
@@ -19,19 +19,9 @@ def set_required_state(required_state: typing.Dict[str, type]) -> None:
     injector.required_state = required_state
 
 
-def provider(func: typing.Callable) -> None:
+def add_provider(func: typing.Callable) -> None:
     injector = _get_default_injector()
-
-    sig = inspect.signature(func)
-
-    params = sig.parameters.values()
-    for param in params:
-        assert param.annotation is not inspect.Signature.empty
-        assert not isinstance(param.annotation, str)
-
-    assert sig.return_annotation is not inspect.Signature.empty
-    assert not isinstance(sig.return_annotation, str)
-    injector.providers[sig.return_annotation] = func
+    injector.add_provider(func)
 
 
 def inject(func: typing.Callable) -> dependency.InjectedFunction:

--- a/dependency/wrappers.py
+++ b/dependency/wrappers.py
@@ -1,4 +1,3 @@
-import inspect
 import typing
 
 import dependency

--- a/examples/test_framework.py
+++ b/examples/test_framework.py
@@ -38,7 +38,7 @@ def run_tests():
 # import os
 #
 #
-# @dependency.provider
+# @dependency.add_provider
 # def get_temp_dir() -> TemporaryDirectory:
 #     """
 #     A temporary directory component that may be injected into test cases.

--- a/examples/web_framework.py
+++ b/examples/web_framework.py
@@ -23,42 +23,42 @@ QueryParam = typing.NewType('QueryParam', str)
 URLArg = typing.TypeVar('URLArg')
 
 
-@dependency.provider
+@dependency.add_provider
 def get_request(environ: Environ) -> Request:
     return Request(environ)
 
 
-@dependency.provider
+@dependency.add_provider
 def get_method(environ: Environ) -> Method:
     return Method(environ['REQUEST_METHOD'].upper())
 
 
-@dependency.provider
+@dependency.add_provider
 def get_path(environ: Environ) -> Path:
     return Path(environ['SCRIPT_NAME'] + environ['PATH_INFO'])
 
 
-@dependency.provider
+@dependency.add_provider
 def get_headers(environ: Environ) -> Headers:
     return Headers(environ)
 
 
-@dependency.provider
+@dependency.add_provider
 def get_header(name: dependency.ParamName, headers: Headers) -> Header:
     return Header(headers.get(name.replace('_', '-')))
 
 
-@dependency.provider
+@dependency.add_provider
 def get_queryparams(environ: Environ) -> QueryParams:
     return QueryParams(url_decode(environ.get('QUERY_STRING', '')))
 
 
-@dependency.provider
+@dependency.add_provider
 def get_queryparam(name: dependency.ParamName, params: QueryParams) -> QueryParam:
     return QueryParam(params.get(name))
 
 
-@dependency.provider
+@dependency.add_provider
 def get_url_arg(name: dependency.ParamName, args: URLArgs) -> URLArg:
     return args.get(name)
 

--- a/tests/test_dependancy.py
+++ b/tests/test_dependancy.py
@@ -66,7 +66,7 @@ def test_injection():
 
 def test_wrappers():
     """
-    Test the `@dependency.provider` and `@depenency.inject` wrappers.
+    Test the `@dependency.add_provider` and `@depenency.inject` wrappers.
     """
     class Environ(dict):
         pass
@@ -77,11 +77,11 @@ def test_wrappers():
     class Headers(dict):
         pass
 
-    @dependency.provider
+    @dependency.add_provider
     def get_method(environ: Environ) -> Method:
         return Method(environ['METHOD'])
 
-    @dependency.provider
+    @dependency.add_provider
     def get_headers(environ: Environ) -> Headers:
         headers = {}
         for key, value in environ.items():


### PR DESCRIPTION
`@dependency.provider` becomes `@dependency.add_provider`.
We also now add this functionality onto the `Injector` class, so that the core and the wrapper interfaces mirror each other nicely now.